### PR TITLE
Compilation failed on Solaris 11.2 GCC 4.8.2 because of std::i...

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -190,6 +190,7 @@
             'ldflags': [ '-m64' ],
           }],
           [ 'OS=="solaris"', {
+            'defines': ['_GLIBCXX_USE_C99_MATH'],
             'cflags': [ '-pthreads' ],
             'ldflags': [ '-pthreads' ],
             'cflags!': [ '-pthread' ],


### PR DESCRIPTION
Try to fix build issue #9351
../deps/v8/src/conversions-inl.h:70:7: error: 'builtin_isnan' is not a member of 'std'
